### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # @TanStack/Bling
 
-Framework agnostic transpilation utilities for client/server RPCs, env isoluation, islands, module splitting, and more.
+Framework agnostic transpilation utilities for client/server RPCs, env isolation, islands, module splitting, and more.
 
-<!-- Use the force, Luke! -->
+<!-- Use the force, Luke! -- Obi Wan Kenobi -->


### PR DESCRIPTION
I'm not sure what this project is going to be but I am excited for it. I did notice a small typo in the README:

>  env isoluation

This should be "env isolation"

I imagine you will be updating the readme with more information but it couldn't hurt for its current state to be accurate. This PR just fixes that typo