### PR TITLE
fixing the GET method option on the server$ utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ The `secret$` function can be used to scope any expression to the server (secret
 ```tsx
 import { secret$ } from '@tanstack/bling'
 
-const secretMessage = secret$('It is a secret!')')
+const secretMessage = secret$('It is a secret!')
 ```
 
 Server Output:
 
 ```tsx
-const secretMessage = server$('It is a secret!')')
+const secretMessage = server$('It is a secret!')
 ```
 
 Client Output:
@@ -183,9 +183,11 @@ This can be used to code-split React/Solid components too:
 import { import$ } from '@tanstack/bling'
 import { lazy } from 'react'
 
-const fn = lazy(() => import$({
-  default: () => <div>Hello World!</div>,
-}))
+const fn = lazy(() =>
+  import$({
+    default: () => <div>Hello World!</div>,
+  }),
+)
 ```
 
 Output:
@@ -265,6 +267,6 @@ console.log(result) // 'Hello World!'
 </details>
 <!-- Use the force, Luke! -->
 
-  - [`websocket$`](#websocket)
-  - [`lazy$`](#lazy)
-  - [`interactive$`/`island$`](#interactive)
+- [`websocket$`](#websocket)
+- [`lazy$`](#lazy)
+- [`interactive$`/`island$`](#interactive)

--- a/packages/bling/src/types.ts
+++ b/packages/bling/src/types.ts
@@ -21,7 +21,7 @@ export type FetchFnReturn<T extends AnyFetchFn> = Awaited<
 
 export type CreateFetcherFn = <T extends AnyFetchFn>(
   fn: T,
-  opts?: FetchFnCtxWithRequest,
+  opts?: FetchFnCtxWithRequest | FetchFnCtxOptions,
 ) => Fetcher<T>
 
 export type FetcherFn<T extends AnyFetchFn> = (

--- a/packages/bling/src/utils/utils.ts
+++ b/packages/bling/src/utils/utils.ts
@@ -267,6 +267,10 @@ export function resolveRequestHref(
       ? `${pathname}?payload=${encodeURIComponent(payloadInit.body as string)}`
       : pathname
 
+  if (method.toLocaleLowerCase() === 'get') {
+    delete payloadInit.body
+  }
+
   return new URL(
     resolved,
     typeof document !== 'undefined' ? window.location.href : `http://localhost`,


### PR DESCRIPTION
Looks like the `server$(() => {}, { method: 'GET'})` was failing both at the type level and functionally. This PR fixes those so we can make get requests again!