### PR TITLE
Fix apparent typo in Vite plugin

### DIFF
--- a/packages/bling/src/vite.ts
+++ b/packages/bling/src/vite.ts
@@ -78,10 +78,7 @@ export function bling(opts?: { babel?: Options['babel'] }): Plugin {
         return compiled.code
       }
 
-      if (
-        code.includes('fetch$(' || code.includes('split$(')) ||
-        code.includes('server$(')
-      ) {
+      if (/(?:fetch|split|server)\$\(/.test(code)) {
         const compiled = await compileFile({
           code,
           viteCompile,


### PR DESCRIPTION
Was just browsing the code and noticed a probable misplaced parenthesis:

```diff
  if (
    code.includes(
-     'fetch$(' || code.includes('split$(')
+     'fetch$('
    ) ||
+   code.includes('split$(') ||
    code.includes('server$(')
  ) {
```

Fixed and switched to a regex to avoid multiple passes.